### PR TITLE
Add README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Maintainer: Mateus Meneses, mateusmenezes95@gmail.com **
 
 # **File System**
 
-- [doogie_bringup] : Package with launch files to bringup Doogie Mouse robot controllers.
-- [doogie_drivers]: Cotains drivers used by Doogie Mouse robot **URDF**.
+- [doogie_bringup] : Package with launch files to bringup Doogie Mouse robot controllers and hardware device drivers.
+- [doogie_drivers]: Contains drivers used by Doogie Mouse robot.
 
 </br>
 
@@ -62,7 +62,8 @@ Attention, if you haven't installed [ROS] yet, please check [Ubuntu install of R
 
 **Building:**
 
-First, lets create a catkin workspace.
+First, lets create a catkin workspace. 
+>If `doogie_ws` already exists, you can skip this step.
 
     mkdir -p ~/doogie_ws/src
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Please report bugs and request features using the [Issue Tracker].
 
 [BIR - Brazilian Institute of Robotics]: https://github.com/Brazilian-Institute-of-Robotics
 [Mateus Meneses]: https://github.com/doogie-mouse/doogie_robot/commits?author=mateusmenezes95
+[doogie_bringup]: doogie_bringup
+[doogie_drivers]: doogie_drivers
 [doogie_base]: http://github.com/doogie-mouse/doogie_base.git
 [doogie_gazebo]: doogie_gazebo
 [doogie_gazebo/Tutorials]: http://github.com/doogie-mouse/doogie_robot/wiki/doogie_gazebo

--- a/doogie_robot/package.xml
+++ b/doogie_robot/package.xml
@@ -8,7 +8,7 @@
 
   <maintainer email="mateusmenezes95@gmail.com">Mateus Menezes</maintainer>
   <maintainer email="caioaamaral@gmail.com">Caio Amaral</maintainer>
-  <autor email="mateusmenezes95@gmail.com">Mateus Menezes</autor>
+  <author email="mateusmenezes95@gmail.com">Mateus Menezes</author>
 
   <license>Apache 2.0</license>
 


### PR DESCRIPTION
Do not merge yet! 

I've just made doogie_robot readme's repository file, it describes what is the doogie_robot stack and how to install it.

As I made in doogie_simulator and doogie_base, I recommend creating nested readme's for each package from the stack just for describing its relevant informations (i.e. launchfiles, parameters, etc.)

Could you make it? I fell I didn't realize yet completely how those packages are working. **After it**, we can also merge the  License Add pull request.